### PR TITLE
WIP: capturing my thoughts at this point

### DIFF
--- a/superscore/backends/__init__.py
+++ b/superscore/backends/__init__.py
@@ -1,0 +1,11 @@
+__all__ = ["BACKENDS", "DEFAULT_BACKEND"]
+
+import logging
+
+logging = logging.getLogger(__name__)
+
+
+def _get_backend(backend: str):
+    if backend == 'filestore':
+        from .filestore import FilestoreBackend
+        return FilestoreBackend

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -1,0 +1,41 @@
+"""
+Base configuration backend interface
+"""
+from typing import Any, Generator
+from uuid import UUID
+
+# from ..model import Entry  # Skipped due to circular import
+
+
+class _Backend:
+    """
+    Base class for configuration backend.
+    """
+    @property
+    def root(self) -> Any:
+        """Returns the root Entry.  Could just use a static node uuid"""
+        raise NotImplementedError
+
+    def get_entry(self, meta_id: UUID) -> Any:
+        """Get entry with ``meta_id``.  Should attach the backend before returning"""
+        raise NotImplementedError
+
+    def _attach_backend(self, entry: Any) -> Any:
+        """
+        Attach source / backend information so multi-backend works with read-write
+        attaches fill method for replaceing uuids with dataclasses
+        attaches save method for applying singular change
+        """
+        raise NotImplementedError
+
+    def save_entry(self, entry: Any):
+        """Save a specific entry"""
+        raise NotImplementedError
+
+    def delete_entry(self, entry: Any) -> None:
+        """Delete meta_id from the system (all instances)"""
+        raise NotImplementedError
+
+    def search(self, **search_kwargs) -> Generator[Any, None, None]:
+        """Yield a MetaBase objects corresponding matching ``search_kwargs"""
+        raise NotImplementedError

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -1,0 +1,271 @@
+"""
+Backend for configurations backed by files
+"""
+
+import contextlib
+import json
+import logging
+import os
+import shutil
+from typing import Any, Dict, Generator, Optional
+from uuid import UUID, uuid4
+
+from apischema import deserialize, serialize
+
+from superscore.backends.core import _Backend
+from superscore.model import (Collection, Entry, Parameter, Root, Snapshot,
+                              Value)
+from superscore.utils import build_abs_path
+
+# write, copy/move mode
+# serialize backends
+
+logger = logging.getLogger(__name__)
+
+UUID_ATTR_MAP = {
+    Parameter: [],
+    Value: [],
+    Collection: ['parameters', 'collections'],
+    Snapshot: ['values', 'snapshots'],
+}
+
+
+class FilestoreBackend(_Backend):
+    """
+    Filestore configuration backend.
+    Unique aspects:
+    entry cache, filled with _load_or_initialize type method
+    save method saves entire file, and therefore all Entries
+
+    default method here is to store everything as a flattened dictionary for
+    easier access, but serialization must keep Node structure (UUID references
+    result in missing data)
+    """
+    _entry_cache: Dict[UUID, Entry] = {}
+    _root: Root
+
+    def __init__(
+        self,
+        path: str,
+        initialize: bool = False,
+        cfg_path: Optional[str] = None
+    ) -> None:
+        self._root = None
+        self.path = path
+        if cfg_path is not None:
+            cfg_dir = os.path.dirname(cfg_path)
+            self.path = build_abs_path(cfg_dir, path)
+        else:
+            self.path = path
+
+        if initialize:
+            self.initialize()
+
+    def _load_or_initialize(self) -> Dict[str, Any]:
+        """
+        Load an existing database or initialize a new one.
+        Returns the entry cache for this backend
+        """
+        if self._root is None:
+            try:
+                self._root = self.load()
+            except FileNotFoundError:
+                logger.debug("Initializing new database")
+                self.initialize()
+                self._root = self.load()
+
+        # flatten create entry cache
+        self.flatten_and_cache(self._root)
+
+        return self._entry_cache
+
+    def flatten_and_cache(self, entry: Any):
+        """
+        Flatten ``node`` recursively, adding them to ``self._entry_cache``.
+        Does not replace any dataclass with its uuid
+        Currently hard codes structure of Parameters, could maybe refactor later
+        """
+        attrs = UUID_ATTR_MAP.get(type(entry), [])
+        for attr in attrs:
+            field = getattr(entry, attr)
+
+            # dicts may need to be supported eventually, but not today
+            if isinstance(field, list):
+                for item in field:
+                    self.maybe_add_to_cache(item)
+                    self.flatten_and_cache(item)
+            elif field is None:
+                continue
+            else:
+                self.maybe_add_to_cache(field)
+                self.flatten_and_cache(field)
+
+    def maybe_add_to_cache(self, item: Any) -> None:
+        if isinstance(item, UUID) or item is None:
+            return
+        meta_id = item.meta_id
+        if meta_id in self._entry_cache:
+            # duplicate uuids found
+            return
+
+        self._entry_cache[meta_id] = self._attach_backend(item)
+
+    def swap_dclass_for_uuids(self) -> None:
+        # TODO: Make a method on the dataclasses.  Keep attribute knowledge with dclass
+        for entry in self._entry_cache.values():
+            for attr in UUID_ATTR_MAP.get(type(entry), []):
+                field = getattr(entry, attr)
+                if isinstance(field, list):
+                    new_list = [getattr(item, 'meta_id', item) for item in field]
+                    setattr(entry, attr, new_list)
+                elif field is None:
+                    continue
+                else:
+                    setattr(entry, attr, field.meta_id)
+
+    def initialize(self):
+        """
+        Initialize a new JSON file database.
+
+        Raises
+        ------
+        PermissionError
+            If the JSON file specified by ``path`` already exists.
+
+        Notes
+        -----
+        This exists because the `.store` and `.load` methods assume that the
+        given path already points to a readable JSON file. In order to begin
+        filling a new database, an empty but valid JSON file is created.
+        """
+
+        # Do not overwrite existing databases
+        if os.path.exists(self.path) and os.stat(self.path).st_size > 0:
+            raise PermissionError("File {} already exists. Can not initialize "
+                                  "a new database.".format(self.path))
+        # Dump an empty dictionary
+        self.store({})
+
+    def store(self, root_node: Optional[Root] = None) -> None:
+        """
+        Stash the database in the JSON file.
+
+        This is a two-step process:
+
+        1. Write the database out to a temporary file
+        2. Move the temporary file over the previous database.
+
+        Step 2 is an atomic operation, ensuring that the database
+        does not get corrupted by an interrupted json.dump.
+
+        Parameters
+        ----------
+        db : dict
+            Dictionary to store in JSON.
+        """
+        temp_path = self._temp_path()
+        # TODO: this doesn't take db, should serialize root directly
+        if root_node is None:
+            serialized = serialize(Root, self._root)
+        else:
+            serialized = serialize(Root, Root(meta_id=Root.ROOT_ID))
+
+        try:
+            with open(temp_path, 'w') as fd:
+                json.dump(serialized, fd, indent=2)
+
+            if os.path.exists(self.path):
+                shutil.copymode(self.path, temp_path)
+            shutil.move(temp_path, self.path)
+        except BaseException as ex:
+            logger.debug('JSON db move failed: %s', ex, exc_info=ex)
+            # remove temporary file
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+            raise
+
+    def _temp_path(self) -> str:
+        """
+        Return a temporary path to write the json file to during "store".
+
+        Includes a hash for uniqueness
+        (in the cases where multiple temp files are written at once).
+        """
+        directory = os.path.dirname(self.path)
+        filename = (
+            f"_{str(uuid4())[:8]}"
+            f"_{os.path.basename(self.path)}"
+        )
+        return os.path.join(directory, filename)
+
+    def load(self) -> Optional[Root]:
+        """
+        Load database from stored path as a nested structure (deserialize as Root)
+        """
+        with open(self.path) as fp:
+            serialized = json.load(fp)
+
+        return deserialize(Root, serialized)
+
+    def _attach_backend(self, entry: Entry) -> Entry:
+        """
+        Attach source / backend information so multi-backend works with read-write
+        """
+        entry.backend = self
+        return entry
+
+    @property
+    def root(self) -> Root:
+        with _load_and_store_context(self):
+            return self._attach_backend(self._root)
+
+    def get_entry(self, meta_id: str) -> Entry:
+        """Return the entry, ensure the backend is attached"""
+        return self._attach_backend(self._entry_cache[meta_id])
+
+    def save_entry(self, entry: Entry):
+        """Save specific entry into database.  Assumes connections are made properly"""
+        return
+        # with _load_and_store_context as db:
+        #     # Ensure uuids are filled, links are proper
+        #     # make sure it's reachable from root node?
+        #     pass
+
+    def delete_entry(self, entry: Entry) -> None:
+        """Delete meta_id from the system (all instances)"""
+        with _load_and_store_context(self) as db:
+            # find and remove all references to meta_id
+            for entry in self._entry_cache.values():
+                for attr in UUID_ATTR_MAP[type(entry)]:
+                    value = getattr(entry, attr)
+                    if isinstance(value, list):
+                        # Find entry with ``meta_id`` in list and remove it
+                        continue
+
+                    else:
+                        if value.meta_id == '':
+                            setattr(entry, attr, None)
+
+            # remove from entry cache
+            db.pop('')
+
+    def search(self, **search_kwargs) -> Generator[Any, None, None]:
+        raise NotImplementedError
+
+    def clear_cache(self) -> None:
+        """Clear the loaded cache and stored root"""
+        self._entry_cache = {}
+        self._root = None
+
+
+@contextlib.contextmanager
+def _load_and_store_context(
+    backend: FilestoreBackend
+) -> Generator[Dict[UUID, Any], None, None]:
+    """
+    Context manager used to load, and optionally store the JSON database.
+    Yields the flattened entry cache
+    """
+    db = backend._load_or_initialize()
+    yield db
+    backend.store()

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -1,0 +1,69 @@
+"""Client for superscore.  Used for """
+from typing import Any, List
+
+from superscore.backends.core import _Backend
+from superscore.model import Entry, Root
+
+ACTIONS = [
+    # Always allowed
+    'authenticate',
+    'search',
+    'compare',
+    'copy',
+    # Usually allowed
+    'save',
+    # Often restricted
+    'delete',
+    'apply',
+]
+
+
+class Client:
+    backend: _Backend
+    authenticator: Any
+
+    def __init__(self, backend=None, **kwargs) -> None:
+        # if backend is None, startup default filestore backend
+        return
+
+    @classmethod
+    def from_config(cls, cfg=None):
+        raise NotImplementedError
+
+    def search(self, **post) -> List[Entry]:
+        """Search by key-value pair."""
+        return self.backend.search(**post)
+
+    def save(self, entry: Entry):
+        """Save information in ``entry`` to database"""
+        self.backend.save_entry(entry)
+
+    def delete(self, entry: Entry) -> None:
+        """Remove item from backend, depending on backend"""
+        self.backend.delete_entry(entry)
+
+    def get_root(self) -> Root:
+        """Return root Node of databases"""
+        return self.backend.root
+
+    def compare(self, entry_l: Entry, entry_r: Entry) -> Any:
+        """Compare two entries.  Should be of same type, and return a diff"""
+        raise NotImplementedError
+
+    def apply(self, entry: Entry):
+        """Apply settings found in ``entry``.  If no values found, no-op"""
+        raise NotImplementedError
+
+    def copy(self, source: Entry):
+        """Recursively copy ``source``, make new name, clear any stored values"""
+        raise NotImplementedError
+
+    def validate(self, entry: Entry):
+        """
+        Validate ``entry`` is properly formed and able to be inserted into
+        the backend.  Includes checks the following:
+        - dataclass is valid
+        - reachable from root
+        - references are not cyclical
+        """
+        raise NotImplementedError

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -1,5 +1,8 @@
+from typing import List
+
 import pytest
 
+from superscore.backends.core import _Backend
 from superscore.model import Collection, Parameter, Root, Snapshot, Value
 
 
@@ -51,3 +54,15 @@ def sample_database():
     root.entries.append(snap_1)
 
     return root
+
+
+@pytest.fixture
+def test_backends() -> List[_Backend]:
+    # TODO: make a sample backend fixtures
+    return []
+
+
+@pytest.fixture
+def backends(request, test_backends: List[_Backend]):
+    i = request.param
+    return test_backends[i]

--- a/superscore/tests/db/db.json
+++ b/superscore/tests/db/db.json
@@ -1,0 +1,155 @@
+{
+  "entries": [
+    {
+      "Parameter": {
+        "meta_id": "3cdf0101-b52b-4f85-8d50-a783c995bed1",
+        "name": "parameter 1",
+        "description": "parameter in root",
+        "creation": "2024-02-27T23:56:40.490940",
+        "pv_name": "MY:MOTOR:mtr1.ACCL",
+        "read_only": false
+      }
+    },
+    {
+      "Value": {
+        "meta_id": "2a05002a-04e6-46e7-b6fb-4d53fa64d393",
+        "name": "value 1",
+        "description": "Value created from parameter 1",
+        "creation": "2024-02-27T23:56:40.490973",
+        "data": 2,
+        "origin": {
+          "meta_id": "3cdf0101-b52b-4f85-8d50-a783c995bed1",
+          "name": "parameter 1",
+          "description": "parameter in root",
+          "creation": "2024-02-27T23:56:40.490940",
+          "pv_name": "MY:MOTOR:mtr1.ACCL",
+          "read_only": false
+        }
+      }
+    },
+    {
+      "Collection": {
+        "meta_id": "342c1e12-fbe9-47cb-96ab-43105ab250a3",
+        "name": "collection 1",
+        "description": "collection defining some motor fields",
+        "creation": "2024-02-27T23:56:40.491000",
+        "parameters": [
+          {
+            "meta_id": "250ac539-dbaf-46bc-98c1-dee46d5021ac",
+            "name": "coll_1_field_ACCL",
+            "description": "motor field ACCL",
+            "creation": "2024-02-27T23:56:40.491169",
+            "pv_name": "MY:PREFIX:mtr1.ACCL",
+            "read_only": false
+          },
+          {
+            "meta_id": "c30e61dd-09ee-4b5c-9cc8-2bbe53ccbdf0",
+            "name": "coll_1_field_VELO",
+            "description": "motor field VELO",
+            "creation": "2024-02-27T23:56:40.491206",
+            "pv_name": "MY:PREFIX:mtr1.VELO",
+            "read_only": false
+          },
+          {
+            "meta_id": "86045b0e-7535-40fc-b183-0fe469ccd398",
+            "name": "coll_1_field_PREC",
+            "description": "motor field PREC",
+            "creation": "2024-02-27T23:56:40.491239",
+            "pv_name": "MY:PREFIX:mtr1.PREC",
+            "read_only": false
+          }
+        ],
+        "collections": []
+      }
+    },
+    {
+      "Snapshot": {
+        "meta_id": "7ec42acd-cf17-47fa-b00f-512c318bcb55",
+        "name": "snapshot 1",
+        "description": "Snapshot created from collection 1",
+        "creation": "2024-02-27T23:56:40.491138",
+        "origin": {
+          "meta_id": "342c1e12-fbe9-47cb-96ab-43105ab250a3",
+          "name": "collection 1",
+          "description": "collection defining some motor fields",
+          "creation": "2024-02-27T23:56:40.491000",
+          "parameters": [
+            {
+              "meta_id": "250ac539-dbaf-46bc-98c1-dee46d5021ac",
+              "name": "coll_1_field_ACCL",
+              "description": "motor field ACCL",
+              "creation": "2024-02-27T23:56:40.491169",
+              "pv_name": "MY:PREFIX:mtr1.ACCL",
+              "read_only": false
+            },
+            {
+              "meta_id": "c30e61dd-09ee-4b5c-9cc8-2bbe53ccbdf0",
+              "name": "coll_1_field_VELO",
+              "description": "motor field VELO",
+              "creation": "2024-02-27T23:56:40.491206",
+              "pv_name": "MY:PREFIX:mtr1.VELO",
+              "read_only": false
+            },
+            {
+              "meta_id": "86045b0e-7535-40fc-b183-0fe469ccd398",
+              "name": "coll_1_field_PREC",
+              "description": "motor field PREC",
+              "creation": "2024-02-27T23:56:40.491239",
+              "pv_name": "MY:PREFIX:mtr1.PREC",
+              "read_only": false
+            }
+          ],
+          "collections": []
+        },
+        "values": [
+          {
+            "meta_id": "91aa717f-a51f-4672-98d8-85a0523f5513",
+            "name": "coll_1_fld_ACCL value",
+            "description": "motor_field_ACCL value",
+            "creation": "2024-02-27T23:56:40.491187",
+            "data": 2,
+            "origin": {
+              "meta_id": "250ac539-dbaf-46bc-98c1-dee46d5021ac",
+              "name": "coll_1_field_ACCL",
+              "description": "motor field ACCL",
+              "creation": "2024-02-27T23:56:40.491169",
+              "pv_name": "MY:PREFIX:mtr1.ACCL",
+              "read_only": false
+            }
+          },
+          {
+            "meta_id": "29b23e86-36fd-4ca7-a626-44465d13f81f",
+            "name": "coll_1_fld_VELO value",
+            "description": "motor_field_VELO value",
+            "creation": "2024-02-27T23:56:40.491222",
+            "data": 2,
+            "origin": {
+              "meta_id": "c30e61dd-09ee-4b5c-9cc8-2bbe53ccbdf0",
+              "name": "coll_1_field_VELO",
+              "description": "motor field VELO",
+              "creation": "2024-02-27T23:56:40.491206",
+              "pv_name": "MY:PREFIX:mtr1.VELO",
+              "read_only": false
+            }
+          },
+          {
+            "meta_id": "40f1e153-2ae5-4940-9015-2ae49d3edd2f",
+            "name": "coll_1_fld_PREC value",
+            "description": "motor_field_PREC value",
+            "creation": "2024-02-27T23:56:40.491261",
+            "data": 6,
+            "origin": {
+              "meta_id": "86045b0e-7535-40fc-b183-0fe469ccd398",
+              "name": "coll_1_field_PREC",
+              "description": "motor field PREC",
+              "creation": "2024-02-27T23:56:40.491239",
+              "pv_name": "MY:PREFIX:mtr1.PREC",
+              "read_only": false
+            }
+          }
+        ],
+        "snapshots": []
+      }
+    }
+  ]
+}

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -1,0 +1,30 @@
+import pytest
+
+from superscore.backends.core import _Backend
+from superscore.model import Parameter
+
+
+@pytest.mark.parametrize('backends', [0], indirect=True)
+def test_save_entry(backends: _Backend):
+    new_entry = Parameter()
+
+    backends.save_entry(new_entry)
+    found_entry = backends.get_entry(new_entry.meta_id)
+    assert found_entry == new_entry
+
+
+@pytest.mark.parametrize('backends', [0], indirect=True)
+def test_delete_entry(backends: _Backend):
+    entry = backends.root[0]
+    backends.delete_entry(entry)
+
+    assert backends.get_entry(entry.meta_id) is None
+
+
+@pytest.mark.parametrize('backends', [0], indirect=True)
+def test_search_entry(backends: _Backend):
+    # Given an entry we know is in the backend
+    # Search by type
+    # Search by field name
+    # search by description
+    assert True

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -1,0 +1,38 @@
+from superscore.client import Client
+from superscore.model import Parameter, Value
+
+# fixture for each backend
+
+
+def test_save(client: Client):
+    new_entry = Parameter()
+    client.save(new_entry)
+
+    assert client.search(meta_id=new_entry.meta_id)
+
+
+def test_delete(client: Client):
+    new_entry = Parameter()
+    client.save(new_entry)
+
+    client.delete(new_entry)
+    assert not client.search(meta_id=new_entry.meta_id)
+
+
+def test_compare(client: Client):
+    # should differ in uuid, but contents are identical
+    assert not client.compare(Parameter(), Parameter())
+
+    # contents are different
+    assert client.compare(Parameter(pv_name='FOO'), Parameter(pv_name='BAR'))
+    assert client.compare(Value(data=1), Value(data='1'))
+
+
+def test_apply(client: Client):
+    # TODO: figure out how we want to mock the EPICS backend.  Caproto?
+    assert True
+
+
+def test_from_config(client: Client):
+    # a smoke test for loading from a config file
+    assert True

--- a/superscore/utils.py
+++ b/superscore/utils.py
@@ -1,3 +1,28 @@
+"""
+Helper functions and utilities
+"""
+
+import os
 from pathlib import Path
 
 SUPERSCORE_SOURCE_PATH = Path(__file__).parent
+
+
+def build_abs_path(basedir: str, path: str) -> str:
+    """
+    Builds an abs path starting at basedir if path is not already absolute.
+    ~ and ~user constructions will be expanded, so ~/path is considered absolute.
+    If path is absolute already, this function returns path without modification.
+
+    Parameters
+    ----------
+    basedir : str
+        If path is not absolute already, build an abspath
+        with path starting here.
+    path : str
+        The path to convert to absolute.
+    """
+    path = os.path.expanduser(path)
+    if not os.path.isabs(path):
+        return os.path.abspath(os.path.join(basedir, path))
+    return path


### PR DESCRIPTION
## Description
(Capturing my thoughts here, will eventually transfer this into a proper PR in the main repo)

## Motivation and Context
Various thoughts I'll catalog here.  The main thing I was doing here is laying out the methods for client and backend interfaces.  Broadly the _Backend should only deal with reading/writing from a backend, and the client performs more complex processes with those methods.  If you're reading through this diff, there are a few incomplete thoughts I'll try to expound on here. 

I started with the Filestore Backend here, stealing a good amount of lessons-learned from our `happi` backend

### MultiBackend (attaching a backend)
I think if we're going to support multiple types of backend (text, database, etc), it makes sense to try to support them at the same time.  Once an application (GUI or otherwise) starts gathering and working with `Entry`'s, it'll need to know where a given `Entry` comes from.  In this case I think it makes sense to attach the backend to any `Entry` it returns, so any time the client needs to operate it has easy access to the backend  in question.  

The alternative is, of course, to only have the app open with one backend at a time.  This is much simpler, but then we have multiple clients and GUI applications open at the same time.  Maybe this is the proper target for a first pass, but adding it back in after the fact will be invasive surgery

### authenticator
I think there's a few ways of authentication to expect.  And once we expect more than one we should have some kind of authenticator object to interact with.  These would include
* user / password (with what backend?  Configured in a configfile?)
* kerberos (LCLS)
* Vault (soon to be at LCLS)
* ... and more?

In the end I've never made one before so I don't know what interface to sketch out.  I'll get there

### Restricted actions
I imagine this is just a list of Client methods, but how we configure this is up in the air.  
* how many restriction levels?  (just one?)
* Where do we configure restriction levels? (config file?)
* How  do we implement this? (decorator wrapping function that consults a list somewhere?)

## How Has This Been Tested?
I was sketching out tests

## Where Has This Been Documented?
This PR.

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
